### PR TITLE
Initialize google analytics based on if project tracking id is available

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -10,7 +10,9 @@ const container = document.getElementById('root');
 const root = createRoot(container);
 const trackingId = process.env.GOOGLE_ANALYTICS_TRACKING_ID;
 
-ReactGA.initialize(trackingId);
+if (trackingId) {
+  ReactGA.initialize(trackingId);
+}
 
 root.render(
   <ApiErrorBoundaryProvider>

--- a/client/src/utils/trackEvents.js
+++ b/client/src/utils/trackEvents.js
@@ -1,4 +1,4 @@
-const ReactGA = require('react-ga');
+import ReactGA from 'react-ga';
 
 const trackingId = process.env.GOOGLE_ANALYTICS_TRACKING_ID;
 const debug = process.env.NODE_ENV !== 'production';
@@ -6,15 +6,19 @@ const gaOptions = {
   anonymizeIp: true
 };
 
-ReactGA.initialize(trackingId, {
-  debug,
-  gaOptions
-});
+if (trackingId) {
+  ReactGA.initialize(trackingId, {
+    debug,
+    gaOptions
+  });
+}
 
 export const trackEvent = (category, action, label) => {
-  ReactGA.event({
-    category,
-    action,
-    label
-  });
+  if (trackingId) {
+    ReactGA.event({
+      category,
+      action,
+      label
+    });
+  }
 };


### PR DESCRIPTION
﻿Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Add google analytics to scripts and initialize google analytics based on wether a project trackign id is available.



## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] Documentation update  
  

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
##


### **Test Configuration**:
##


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
