### PR TITLE
Zhaoyu/profile page

### DIFF
--- a/api/models/Conversation.js
+++ b/api/models/Conversation.js
@@ -156,19 +156,18 @@ module.exports = {
   likeConvo: async (conversationId, userId, liked) => {
     try {
       const update = {};
+      update[`likedBy.${userId}`] = { $type: 'date' };
 
       if (liked) {
-        update[`likedBy.${userId}`] = true;
         return await Conversation.findOneAndUpdate(
           { conversationId },
-          { $set: update, $inc: { likes: 1 } },
+          { $currentDate: update, $inc: { likes: 1 } },
           { new: true, upsert: false }
         ).exec();
       } else {
-        update[`likedBy.${userId}`] = false;
         return await Conversation.findOneAndUpdate(
           { conversationId },
-          { $set: update, $inc: { likes: -1 } },
+          { $unset: update, $inc: { likes: -1 } },
           { new: true, upsert: false }
         ).exec();
       }
@@ -200,7 +199,7 @@ module.exports = {
   getLikedConvos: async (userId) => {
     try {
       const filter = {};
-      filter[`likedBy.${userId}`] = true;
+      filter[`likedBy.${userId}`] = { $exists: true };
 
       const dbResponse = await Conversation.find(filter).limit(30).exec();
       return dbResponse;

--- a/api/models/Conversation.js
+++ b/api/models/Conversation.js
@@ -201,7 +201,11 @@ module.exports = {
       const filter = {};
       filter[`likedBy.${userId}`] = { $exists: true };
 
-      const dbResponse = await Conversation.find(filter).limit(30).exec();
+      const sortOrder = {};
+      sortOrder[`likedBy.${userId}`] = -1;
+      sortOrder['title'] = 1;
+
+      const dbResponse = await Conversation.find(filter).limit(30).sort(sortOrder).exec();
       return dbResponse;
     } catch (error) {
       console.log(error);

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -126,7 +126,9 @@ userSchema.methods.toJSON = function () {
     emailVerified: this.emailVerified,
     plugins: this.plugins,
     createdAt: this.createdAt,
-    updatedAt: this.updatedAt
+    updatedAt: this.updatedAt,
+    followers: this.followers,
+    following: this.following
   };
 };
 

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -93,7 +93,15 @@ const userSchema = mongoose.Schema(
     numOfReferrals: {
       type: Number,
       default: 0
-    }
+    },
+    followers: {
+      type: Object,
+      default: {}
+    },
+    following: {
+      type: Object,
+      default: {}
+    },
   },
   { timestamps: true }
 );

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -69,19 +69,12 @@ const followUserController = async (req, res) => {
   try {
     const { user, isFollowing, otherUser } = req.body.arg;
 
-    // Get the users involed from DB
-    const dbUser = await User.findById(user.id).exec();
-    const dbOtherUser = await User.findById(otherUser.id).exec();
-
     // Build the updates
     const userUpdate = {};
     const otherUserUpdate = {};
 
-    userUpdate['following'] = dbUser.following || {};
-    userUpdate['following'][otherUser.id] = { isFollowing: isFollowing, name: otherUser.name, username: otherUser.username };
-
-    otherUserUpdate['followers'] = dbOtherUser.followers || {};
-    otherUserUpdate['followers'][user.id] = { isFollower: isFollowing, name: user.name, username: user.username };
+    userUpdate[`following.${otherUser.id}`] = { isFollowing: isFollowing, name: otherUser.name, username: otherUser.username };
+    otherUserUpdate[`followers.${user.id}`] = { isFollower: isFollowing, name: user.name, username: user.username };
 
     // Updates to the DB
     await User.findByIdAndUpdate(user.id, userUpdate, { new: true, upsert: false });

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -74,8 +74,8 @@ const followUserController = async (req, res) => {
     const otherUserUpdate = {};
 
     // Build the updates
-    userUpdate[`following.${otherUser.id}`] = { isFollowing: isFollowing, name: otherUser.name, username: otherUser.username };
-    otherUserUpdate[`followers.${user.id}`] = { isFollower: isFollowing, name: user.name, username: user.username };
+    userUpdate[`following.${otherUser.id}`] = { name: otherUser.name, username: otherUser.username };
+    otherUserUpdate[`followers.${user.id}`] = { name: user.name, username: user.username };
 
     // Updates to the DB
     if (isFollowing) {

--- a/api/server/routes/convos.js
+++ b/api/server/routes/convos.js
@@ -135,7 +135,7 @@ router.post('/duplicate', requireJwtAuth, async (req, res) => {
 });
 
 router.post('/like', async (req, res) => {
-  const { conversationId, userId, liked } = req.body;
+  const { conversationId, userId, liked } = req.body.arg;
   console.log('hit like router')
   try {
     const dbResponse = await likeConvo(conversationId, userId, liked);

--- a/api/server/routes/user.js
+++ b/api/server/routes/user.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const requireJwtAuth = require('../../middleware/requireJwtAuth');
-const { getUserController, updateUserPluginsController } = require('../controllers/UserController');
+const { getUserController, updateUserPluginsController, followUserController } = require('../controllers/UserController');
 
 const router = express.Router();
 
 router.get('/:userId?', requireJwtAuth, getUserController);
 router.post('/plugins', requireJwtAuth, updateUserPluginsController);
+router.post('/follow', requireJwtAuth, followUserController);
 
 module.exports = router;

--- a/client/src/components/Nav/MobileNav.jsx
+++ b/client/src/components/Nav/MobileNav.jsx
@@ -31,7 +31,7 @@ export default function MobileNav({ setNavVisible }) {
 
   useEffect(() => {
     if (!profileUser) return;
-    if (user.id === userId) {
+    if (user && user.id === userId) {
       setProfileName(localize(lang, 'com_ui_homepage'));
     } else {
       setProfileName(localize(lang, 'com_ui_others_homepage', profileUser.username));

--- a/client/src/components/Nav/MobileNav.jsx
+++ b/client/src/components/Nav/MobileNav.jsx
@@ -18,7 +18,7 @@ export default function MobileNav({ setNavVisible }) {
     else if (location.pathname === '/leaderboard') setTitle(localize(lang, 'com_ui_leaderboard'));
     else if (location.pathname === '/chat/new') setTitle(localize(lang, 'com_ui_new_chat'));
     else if (location.pathname.substring(0, 11) === '/chat/share') setTitle(' ');
-    else if (location.pathname.substring(0, 8) === '/profile') setTitle(localize(lang, 'com_ui_profile'));
+    else if (location.pathname.substring(0, 8) === '/profile') setTitle(localize(lang, 'com_ui_homepage'));
     else if (conversation) setTitle(conversation.title);
     else setTitle(localize(lang, 'com_ui_new_chat'));
   }, [lang, conversation, location.pathname]);

--- a/client/src/components/Nav/index.jsx
+++ b/client/src/components/Nav/index.jsx
@@ -292,7 +292,7 @@ export default function Nav({ navVisible, setNavVisible }) {
               <NavLink
                 className="flex w-full cursor-pointer items-center gap-3 rounded-none px-3 py-3 text-sm text-white transition-colors duration-200 hover:bg-gray-700"
                 svg={() => <HomeIcon />}
-                text={localize(lang, 'com_ui_homepage')}
+                text={localize(lang, 'com_ui_recommendation')}
                 clickHandler={ user ? openHomepageHandler : navigateToRegister }
               />
               <NavLink
@@ -334,7 +334,7 @@ export default function Nav({ navVisible, setNavVisible }) {
                   className="flex w-full cursor-pointer items-center gap-3 rounded-none px-3 py-3 text-sm text-white transition-colors duration-200 hover:bg-gray-700"
                   // Add an SVG or icon for the Profile link here
                   svg={() => <ProfileIcon />}
-                  text={localize(lang, 'com_ui_profile')}
+                  text={localize(lang, 'com_ui_homepage')}
                   clickHandler={ openProfileHandler }
                 />
               )}

--- a/client/src/components/Profile/LikedConversation.tsx
+++ b/client/src/components/Profile/LikedConversation.tsx
@@ -17,6 +17,8 @@ function LikedConversations() {
 
   const [conversations, setConversations] = useState<TConversation[]>([]);
 
+  // Component to display liked conversations
+  // Displays conversation title
   function ListItem({ convo }: { convo: TConversation }) {
     const [copied, setCopied] = useState<boolean>(false);
     const lang = useRecoilValue(store.lang);

--- a/client/src/components/Profile/PublicConversations.tsx
+++ b/client/src/components/Profile/PublicConversations.tsx
@@ -14,6 +14,8 @@ function PublicConversations() {
 
   const [conversations, setConversations] = useState<TConversation[]>([]);
 
+  // Component to display public conversations
+  // Displays conversation title
   function ListItem({ convo }: { convo: TConversation }) {
     const [copied, setCopied] = useState<boolean>(false);
     const lang = useRecoilValue(store.lang);

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -17,7 +17,8 @@ function Profile() {
   const [profileUser, setProfileUser] = useState<TUser | null>(null);
   const [copied, setCopied] = useState<boolean>(false);
   const [isFollower, setIsFollower] = useState<boolean>(false);
-  const followers = 0;
+  const [numOfFollowers, setNumOfFollowers] = useState<number>(0);
+  const [numOfFollowing, setNumOfFollowing] = useState<number>(0);
 
   const { userId = '' } = useParams();
   const { user } = useAuthContext();
@@ -50,8 +51,20 @@ function Profile() {
   useEffect(() => {
     if (getUserByIdQuery.isSuccess) {
       setProfileUser(getUserByIdQuery.data);
-      setIsFollower(getUserByIdQuery.data.followers && getUserByIdQuery.data.followers[`${user?.id}`] ?
-        getUserByIdQuery.data.followers[`${user?.id}`].isFollower : false);
+
+      if (getUserByIdQuery.data.followers) {
+        setIsFollower(getUserByIdQuery.data.followers[`${user?.id}`] ? getUserByIdQuery.data.followers[`${user?.id}`].isFollower : false);
+        setNumOfFollowers(Object.keys(getUserByIdQuery.data.followers).length);
+      } else {
+        setIsFollower(false);
+        setNumOfFollowers(0);
+      }
+
+      if (getUserByIdQuery.data.following) {
+        setNumOfFollowing(Object.keys(getUserByIdQuery.data.following).length);
+      } else {
+        setNumOfFollowing(0);
+      }
     }
   }, [getUserByIdQuery.isSuccess, getUserByIdQuery.data, user]);
 
@@ -64,6 +77,14 @@ function Profile() {
     if (followUserMutation.isSuccess) {
       setProfileUser(followUserMutation.data);
       setIsFollower(!isFollower);
+
+      if (followUserMutation.data.followers) {
+        setNumOfFollowers(Object.keys(followUserMutation.data.followers).length);
+      }
+
+      if (followUserMutation.data.following) {
+        setNumOfFollowing(Object.keys(followUserMutation.data.following).length);
+      }
     }
   }, [followUserMutation.isSuccess, followUserMutation.data]);
 
@@ -144,7 +165,7 @@ function Profile() {
             className='flex flex-col leading-[22px] items-center w-24 text-gray-600 hover:text-black dark:text-gray-400 dark:hover:text-gray-200'
             onClick={() => {setTabValue('followers')}}
           >
-            {followers}
+            {numOfFollowers}
             <br />
             {localize(lang, 'com_ui_followers')}
           </button>
@@ -152,7 +173,7 @@ function Profile() {
             className='flex flex-col leading-[22px] items-center w-24 text-gray-600 hover:text-black dark:text-gray-400 dark:hover:text-gray-200'
             onClick={() => {setTabValue('following')}}
           >
-            {followers}
+            {numOfFollowing}
             <br />
             {localize(lang, 'com_ui_following')}
           </button>

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -102,7 +102,7 @@ function Profile() {
     }
 
     if (profileUser) {
-      if (profileUser.followers && profileUser.followers[`${user?.id}`] && profileUser.followers[`${user?.id}`].isFollower) {
+      if (profileUser.followers && profileUser.followers[`${user?.id}`]) {
         payload['isFollowing'] = false;
       } else {
         payload['isFollowing'] = true;
@@ -117,7 +117,7 @@ function Profile() {
       setProfileUser(getUserByIdQuery.data);
 
       if (getUserByIdQuery.data.followers) {
-        setIsFollower(getUserByIdQuery.data.followers[`${user?.id}`] ? getUserByIdQuery.data.followers[`${user?.id}`].isFollower : false);
+        setIsFollower(getUserByIdQuery.data.followers[`${user?.id}`] ? true : false);
         setNumOfFollowers(Object.keys(getUserByIdQuery.data.followers).length);
       } else {
         setIsFollower(false);
@@ -277,10 +277,13 @@ function Profile() {
       <div className='flex flex-col h-full overflow-y-auto border-t-2'>
         {(tabValue === 'likes') && (<LikedConversations key={userId} />)}
         {(tabValue === 'conversations') && (<PublicConversations key={userId} />)}
+
+        {/*New followers and follwings are added at the end of the object in MongoDB. */}
+        {/*We reverse the array to dsiplay the most recent follwers and followings at the top. */}
         {(tabValue === 'followers') && (
           <div>
             {
-              Object.entries(profileUser ? profileUser.followers : {}).map(([id, info]) =>
+              Object.entries(profileUser ? profileUser.followers : {}).reverse().map(([id, info]) =>
                 <ListItem key={id} id={id} info={info}/>)
             }
           </div>
@@ -288,7 +291,7 @@ function Profile() {
         {(tabValue === 'following') && (
           <div>
             {
-              Object.entries(profileUser ? profileUser.following : {}).map(([id, info]) =>
+              Object.entries(profileUser ? profileUser.following : {}).reverse().map(([id, info]) =>
                 <ListItem key={id} id={id} info={info}/>)
             }
           </div>

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -33,6 +33,8 @@ function Profile() {
   const defaultClasses = 'p-2 rounded-md min-w-[75px] font-normal text-xs';
   const defaultSelected = cn(defaultClasses, 'font-medium data-[state=active]:text-white text-xs text-white');
 
+  // Component to display user's followers and who they are following
+  // Displays username only
   function ListItem({ id, info }: { id: string, info: TUser }) {
     const [copied, setCopied] = useState<boolean>(false);
     const lang = useRecoilValue(store.lang);
@@ -48,6 +50,8 @@ function Profile() {
             {info.username}
           </div>
         </div>
+
+        {/*Copy profile URL button */}
         <button
           className='visible absolute rounded-md right-1 z-10 p-1 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-600'
           onClick={() => {
@@ -151,6 +155,7 @@ function Profile() {
   return (
     <div className='flex flex-col h-full justify-center md:mx-36'>
       <div className='flex flex-col md:flex-row md:gap-6 items-start flex-wrap mt-6 mb-3 md:my-12'>
+        {/*User icon, full name, and username */}
         <div className='flex flex row items-center'>
           <div
             title='User Icon'
@@ -174,6 +179,7 @@ function Profile() {
             </div>
           </div>
         </div>
+        {/*Copy profile page URL button */}
         <div className='flex flex-row self-center px-3 py-3 text-xl gap-4 items-center'>
           <button
             className='w-32 text-gray-600 hover:text-black dark:text-gray-400 dark:hover:text-gray-200'
@@ -215,6 +221,7 @@ function Profile() {
               )}
             </div>
           </button>
+          {/*Number of followers */}
           <button
             className='flex flex-col leading-[22px] items-center w-24 text-gray-600 hover:text-black dark:text-gray-400 dark:hover:text-gray-200'
             onClick={() => {setTabValue('followers')}}
@@ -223,6 +230,7 @@ function Profile() {
             <br />
             {localize(lang, 'com_ui_followers')}
           </button>
+          {/*Number of following */}
           <button
             className='flex flex-col leading-[22px] items-center w-24 text-gray-600 hover:text-black dark:text-gray-400 dark:hover:text-gray-200'
             onClick={() => {setTabValue('following')}}
@@ -232,6 +240,7 @@ function Profile() {
             {localize(lang, 'com_ui_following')}
           </button>
         </div>
+        {/*Follow user button */}
         {(userId !== user?.id && profileUser && user) &&
           <button
             className='self-center w-24 px-3 py-1 text-lg text-center font-bold rounded-md bg-gray-200 text-gray-800 hover:text-black dark:bg-gray-600 dark:text-gray-400 dark:hover:text-gray-200'
@@ -242,6 +251,7 @@ function Profile() {
         }
       </div>
       <hr />
+      {/*Tabs and tab content */}
       <div className='flex flex-col items-center'>
         <Tabs value={tabValue} onValueChange={(value: string) => setTabValue(value)} className={defaultClasses}>
           <TabsList className="bg-white">

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -150,37 +150,31 @@ function Profile() {
 
   return (
     <div className='flex flex-col h-full justify-center md:mx-36'>
-      <div className='flex flex-row items-center flex-wrap mt-6 mb-3 md:my-12'>
-        <div
-          title='User Icon'
-          className='relative flex items-center justify-center my-1 mx-4 md:my-3 md:ml-12'
-        >
-          <img
-            className="rounded-md"
-            src={
-              profileUser?.avatar ||
-              `https://api.dicebear.com/6.x/initials/svg?seed=${profileUser?.name}&fontFamily=Verdana&fontSize=36&size=96`
-            }
-            alt="avatar"
-          />
-        </div>
-        <div className='flex flex-col justify-center mx-3 gap-4 dark:text-gray-200 text-2xl'>
-          <div>
-            {profileUser?.name}
-          </div>
-          <div>
-            {profileUser?.username}
-          </div>
-        </div>
-        {(userId !== user?.id && profileUser && user) &&
-          <button
-            className='ml-9 px-3 py-1 text-lg font-bold rounded-md bg-gray-200 text-gray-800 hover:text-black dark:bg-gray-600 dark:text-gray-400 dark:hover:text-gray-200'
-            onClick={ followUserController }
+      <div className='flex flex-col md:flex-row md:gap-6 items-start flex-wrap mt-6 mb-3 md:my-12'>
+        <div className='flex flex row items-center'>
+          <div
+            title='User Icon'
+            className='relative flex items-center justify-center my-1 mx-4 md:my-3 md:ml-12'
           >
-            {isFollower ? 'Unfollow' : 'Follow'}
-          </button>
-        }
-        <div className='flex flex-row ml-5 py-3 text-xl gap-4 items-center md:ml-9'>
+            <img
+              className="rounded-md"
+              src={
+                profileUser?.avatar ||
+                `https://api.dicebear.com/6.x/initials/svg?seed=${profileUser?.name}&fontFamily=Verdana&fontSize=36&size=96`
+              }
+              alt="avatar"
+            />
+          </div>
+          <div className='flex flex-col justify-center mx-3 gap-4 dark:text-gray-200 text-2xl'>
+            <div>
+              {profileUser?.name}
+            </div>
+            <div>
+              {profileUser?.username}
+            </div>
+          </div>
+        </div>
+        <div className='flex flex-row self-center px-3 py-3 text-xl gap-4 items-center'>
           <button
             className='w-32 text-gray-600 hover:text-black dark:text-gray-400 dark:hover:text-gray-200'
             onClick={() => {
@@ -238,6 +232,14 @@ function Profile() {
             {localize(lang, 'com_ui_following')}
           </button>
         </div>
+        {(userId !== user?.id && profileUser && user) &&
+          <button
+            className='self-center w-24 px-3 py-1 text-lg text-center font-bold rounded-md bg-gray-200 text-gray-800 hover:text-black dark:bg-gray-600 dark:text-gray-400 dark:hover:text-gray-200'
+            onClick={ followUserController }
+          >
+            {isFollower ? localize(lang, 'com_ui_unfollow') : localize(lang, 'com_ui_follow')}
+          </button>
+        }
       </div>
       <hr />
       <div className='flex flex-col items-center'>
@@ -254,10 +256,10 @@ function Profile() {
               </TabsTrigger>
             )}
             <TabsTrigger value='followers' className="text-gray-500 dark:text-gray-200">
-              {'Followers'}
+              {localize(lang, 'com_ui_followers')}
             </TabsTrigger>
             <TabsTrigger value='following' className="text-gray-500 dark:text-gray-200">
-              {'Following'}
+              {localize(lang, 'com_ui_following')}
             </TabsTrigger>
           </TabsList>
         </Tabs>

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -13,7 +13,7 @@ import PublicConversations from './PublicConversations';
 import { Spinner } from '../svg';
 import UserIcon from '../svg/UserIcon';
 
-function Profile() {
+function ProfileContent() {
   const [tabValue, setTabValue] = useState<string>('');
   const [profileUser, setProfileUser] = useState<TUser | null>(null);
   const [copied, setCopied] = useState<boolean>(false);
@@ -300,6 +300,13 @@ function Profile() {
       </div>
     </div>
   );
+}
+
+// To avoid internal state mixture
+function Profile() {
+  const { userId } = useParams();
+
+  return <ProfileContent key={ userId } />
 }
 
 export default Profile;

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -15,6 +15,7 @@ import { Spinner } from '../svg';
 function Profile() {
   const [tabValue, setTabValue] = useState<string>('');
   const [profileUser, setProfileUser] = useState<TUser | null>(null);
+  const [copied, setCopied] = useState<boolean>(false);
 
   const { userId } = useParams();
   const { user, token } = useAuthContext();
@@ -52,7 +53,7 @@ function Profile() {
 
   return (
     <div className='flex flex-col h-full justify-center md:mx-36'>
-      <div className='flex flex-row my-12'>
+      <div className='flex flex-row flex-wrap mt-6 mb-3 md:my-12'>
         <div
           title='User Icon'
           className='relative flex items-center justify-center my-1 mx-4 md:my-3 md:mx-12'
@@ -81,6 +82,55 @@ function Profile() {
               Followers
             </button>
           </div> */}
+        </div>
+        <div className='flex flex-row ml-5 py-3 text-xl gap-4 items-center md:ml-9'>
+          <button
+            className='w-32 text-gray-600 hover:text-black'
+            onClick={() => {
+              if (copied) return;
+              setCopied(true);
+              window.navigator.clipboard.writeText(window.location.href);
+              setTimeout(() => setCopied(false), 2000);
+            }}
+          >
+            <div className='flex flex-col items-center'>
+              {copied ? (
+                <>
+                  <svg
+                    stroke="currentColor"
+                    fill="none"
+                    strokeWidth="2"
+                    viewBox="0 0 24 24"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="h-5 w-5"
+                    height="1em"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                  {localize(lang, 'com_ui_copy_success')}
+                </>
+              ) : (
+                <>
+                  <svg className="h-5 w-5" width="1em" height="1em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <g id="Communication / Share_iOS_Export">
+                      <path id="Vector" d="M9 6L12 3M12 3L15 6M12 3V13M7.00023 10C6.06835 10 5.60241 10 5.23486 10.1522C4.74481 10.3552 4.35523 10.7448 4.15224 11.2349C4 11.6024 4 12.0681 4 13V17.8C4 18.9201 4 19.4798 4.21799 19.9076C4.40973 20.2839 4.71547 20.5905 5.0918 20.7822C5.5192 21 6.07899 21 7.19691 21H16.8036C17.9215 21 18.4805 21 18.9079 20.7822C19.2842 20.5905 19.5905 20.2839 19.7822 19.9076C20 19.4802 20 18.921 20 17.8031V13C20 12.0681 19.9999 11.6024 19.8477 11.2349C19.6447 10.7448 19.2554 10.3552 18.7654 10.1522C18.3978 10 17.9319 10 17 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                    </g>
+                  </svg>
+                  {localize(lang, 'com_ui_share_profile')}
+                </>
+
+              )}
+            </div>
+          </button>
+          {/* <button className='w-24 text-start text-gray-600 hover:text-black'>
+            {localize(lang, 'com_ui_followers')}
+          </button>
+          <button className='w-24 text-start text-gray-600 hover:text-black'>
+            {localize(lang, 'com_ui_following')}
+          </button> */}
         </div>
       </div>
       <hr />

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -16,6 +16,7 @@ function Profile() {
   const [tabValue, setTabValue] = useState<string>('');
   const [profileUser, setProfileUser] = useState<TUser | null>(null);
   const [copied, setCopied] = useState<boolean>(false);
+  const followers = 0;
 
   const { userId } = useParams();
   const { user, token } = useAuthContext();
@@ -53,10 +54,10 @@ function Profile() {
 
   return (
     <div className='flex flex-col h-full justify-center md:mx-36'>
-      <div className='flex flex-row flex-wrap mt-6 mb-3 md:my-12'>
+      <div className='flex flex-row items-center flex-wrap mt-6 mb-3 md:my-12'>
         <div
           title='User Icon'
-          className='relative flex items-center justify-center my-1 mx-4 md:my-3 md:mx-12'
+          className='relative flex items-center justify-center my-1 mx-4 md:my-3 md:ml-12'
         >
           <img
             className="rounded-md"
@@ -67,25 +68,22 @@ function Profile() {
             alt="avatar"
           />
         </div>
-        <div className='flex flex-col justify-center mx-3 gap-4 dark:text-white'>
-          <div className='text-2xl'>
+        <div className='flex flex-col justify-center mx-3 gap-4 dark:text-gray-200 text-2xl'>
+          <div>
             {profileUser?.name}
           </div>
-          <div className='text-2xl'>
+          <div>
             {profileUser?.username}
           </div>
-          {/* <div className='flex flex-row gap-y-6 gap-x-12'>
-            <button onClick={() => setTabValue('following')}>
-              Following
-            </button>
-            <button onClick={() => setTabValue('followers')}>
-              Followers
-            </button>
-          </div> */}
         </div>
+        {(userId !== user?.id) &&
+          <button className='ml-12 px-3 py-1 text-lg font-bold rounded-md bg-gray-200 text-gray-800 hover:text-black dark:bg-gray-600 dark:text-gray-400 dark:hover:text-gray-200'>
+            Follow
+          </button>
+        }
         <div className='flex flex-row ml-5 py-3 text-xl gap-4 items-center md:ml-9'>
           <button
-            className='w-32 text-gray-600 hover:text-black'
+            className='w-32 text-gray-600 hover:text-black dark:text-gray-400 dark:hover:text-gray-200'
             onClick={() => {
               if (copied) return;
               setCopied(true);
@@ -121,16 +119,25 @@ function Profile() {
                   </svg>
                   {localize(lang, 'com_ui_share_profile')}
                 </>
-
               )}
             </div>
           </button>
-          {/* <button className='w-24 text-start text-gray-600 hover:text-black'>
+          <button
+            className='flex flex-col leading-[22px] items-center w-24 text-gray-600 hover:text-black dark:text-gray-400 dark:hover:text-gray-200'
+            onClick={() => {setTabValue('followers')}}
+          >
+            {followers}
+            <br />
             {localize(lang, 'com_ui_followers')}
           </button>
-          <button className='w-24 text-start text-gray-600 hover:text-black'>
+          <button
+            className='flex flex-col leading-[22px] items-center w-24 text-gray-600 hover:text-black dark:text-gray-400 dark:hover:text-gray-200'
+            onClick={() => {setTabValue('following')}}
+          >
+            {followers}
+            <br />
             {localize(lang, 'com_ui_following')}
-          </button> */}
+          </button>
         </div>
       </div>
       <hr />
@@ -147,12 +154,12 @@ function Profile() {
                 {localize(lang, 'com_ui_conversations')}
               </TabsTrigger>
             )}
-            {/* <TabsTrigger value='following' className="text-gray-500 dark:text-gray-200">
-              {'Following'}
-            </TabsTrigger>
             <TabsTrigger value='followers' className="text-gray-500 dark:text-gray-200">
               {'Followers'}
-            </TabsTrigger> */}
+            </TabsTrigger>
+            <TabsTrigger value='following' className="text-gray-500 dark:text-gray-200">
+              {'Following'}
+            </TabsTrigger>
           </TabsList>
         </Tabs>
       </div>

--- a/client/src/components/ui/Recommendations.tsx
+++ b/client/src/components/ui/Recommendations.tsx
@@ -22,7 +22,7 @@ import { Plugin } from '~/components/svg';
 import { useNavigate } from 'react-router-dom';
 import { alternateName } from '~/utils';
 
-export default function Homepage() {
+export default function Recommendations() {
   const [tabValue, setTabValue] = useRecoilState<string>(store.tabValue);
 
   const [convoIdx, setConvoIdx] = useState<number>(0);

--- a/client/src/components/ui/Recommendations.tsx
+++ b/client/src/components/ui/Recommendations.tsx
@@ -280,7 +280,7 @@ export default function Recommendations() {
 
     // Update the Db
     const conversationId = convoData[convoDataKeys[convoIdx]].conversationId;
-    likeConvoMutation.mutate({ conversationId: conversationId, userId: convoUser?.id, liked: !liked });
+    likeConvoMutation.mutate({ conversationId: conversationId, userId: user.id, liked: !liked });
   }
 
   const { screenshotTargetRef } = useScreenshot();

--- a/client/src/components/ui/index.ts
+++ b/client/src/components/ui/index.ts
@@ -7,7 +7,7 @@ export * from './HoverCard';
 export * from './Input';
 export * from './InputNumber';
 export * from './Label';
-export * from './Homepage';
+export * from './Recommendations';
 export * from './ModelSelect';
 export * from './Prompt';
 export * from './Slider';

--- a/client/src/localization/languages/Eng.tsx
+++ b/client/src/localization/languages/Eng.tsx
@@ -1,6 +1,9 @@
 // English phrases
 
 export default {
+  com_ui_followers: 'Followers',
+  com_ui_following: 'Following',
+  com_ui_share_profile: 'Share Profile',
   com_ui_conversations: 'Conversations',
   com_ui_my_likes: 'Likes',
   com_ui_profile: 'Profile',
@@ -9,7 +12,8 @@ export default {
   com_ui_share: 'Share',
   com_ui_public: 'Public',
   com_ui_private: 'Private',
-  com_ui_homepage: 'Home',
+  com_ui_homepage: 'My Profile',
+  com_ui_others_homepage: '{0}\' s Profile',
   com_ui_register_before_like: 'Let\'s make yourself an account',
   com_ui_number_of_likes: '{0} Likes',
   com_ui_register_here: 'Don\'t have an account yet? Click here to register.',

--- a/client/src/localization/languages/Eng.tsx
+++ b/client/src/localization/languages/Eng.tsx
@@ -1,6 +1,8 @@
 // English phrases
 
 export default {
+  com_ui_unfollow: 'Unfollow',
+  com_ui_follow: 'Follow',
   com_ui_followers: 'Followers',
   com_ui_following: 'Following',
   com_ui_share_profile: 'Share Profile',

--- a/client/src/localization/languages/Zh.tsx
+++ b/client/src/localization/languages/Zh.tsx
@@ -1,6 +1,9 @@
 // Chinese phrases
 
 export default {
+  com_ui_followers: '粉丝',
+  com_ui_following: '关注',
+  com_ui_share_profile: '分享主页',
   com_ui_conversations: '对话',
   com_ui_my_likes: '我的点赞',
   com_ui_profile: '个人资料',
@@ -9,7 +12,8 @@ export default {
   com_ui_share: '分享',
   com_ui_public: '公开',
   com_ui_private: '私密',
-  com_ui_homepage: '主页',
+  com_ui_homepage: '我的主页',
+  com_ui_others_homepage: '{0}的主页',
   com_ui_register_before_like: '需注册账号后才能点赞哦',
   com_ui_number_of_likes: '赞 {0}',
   com_ui_register_here: '没有AITok账号？点击这里注册。',

--- a/client/src/localization/languages/Zh.tsx
+++ b/client/src/localization/languages/Zh.tsx
@@ -1,6 +1,8 @@
 // Chinese phrases
 
 export default {
+  com_ui_unfollow: '停止关注',
+  com_ui_follow: '关注',
   com_ui_followers: '粉丝',
   com_ui_following: '关注',
   com_ui_share_profile: '分享主页',

--- a/client/src/routes/index.jsx
+++ b/client/src/routes/index.jsx
@@ -7,8 +7,8 @@ import { Login, Registration, RequestPasswordReset, ResetPassword } from '../com
 import { AuthContextProvider } from '../hooks/AuthContext';
 import ApiErrorWatcher from '../components/Auth/ApiErrorWatcher';
 import Leaderboard from '~/components/ui/Leaderboard';
-import Homepage from '~/components/ui/Homepage';
 import SharedConvo from '~/components/ui/SharedConvo';
+import Recommendations from '~/components/ui/Recommendations';
 
 const AuthLayout = () => (
   <AuthContextProvider>
@@ -63,7 +63,7 @@ export const router = createBrowserRouter([
           },
           {
             path: 'home',
-            element: <Homepage />
+            element: <Recommendations />
           },
           {
             path: 'profile/:userId?',

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -121,3 +121,7 @@ export const likedConversations = (userId: string) => {
 export const publicConversations = (userId: string) => {
   return `/api/convos/publicConvos/${userId}`
 }
+
+export const followUser = () => {
+  return '/api/user/follow'
+}

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -125,3 +125,7 @@ export const publicConversations = (userId: string) => {
 export const followUser = () => {
   return '/api/user/follow'
 }
+
+export const likeConversation = () => {
+  return '/api/convos/like';
+};

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -2,6 +2,10 @@ export const user = () => {
   return '/api/user';
 };
 
+export const userById = (id: string) => {
+  return `/api/user/${id}`
+}
+
 export const userPlugins = () => {
   return '/api/user/plugins';
 };

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -61,6 +61,10 @@ export function getUser(): Promise<t.TUser> {
   return request.get(endpoints.user());
 }
 
+export function getUserById(id: string) {
+  return request.get(endpoints.userById(id));
+}
+
 export const searchConversations = async (
   q: string,
   pageNumber: string

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -147,3 +147,7 @@ export const getPublicConverstaions = (userId: string) => {
 export const followUser = (payload: object): Promise<t.TUser> => {
   return request.post(endpoints.followUser(), { arg: payload });
 }
+
+export function likeConversation(payload: object) {
+  return request.post(endpoints.likeConversation(), { arg: payload });
+}

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -143,3 +143,7 @@ export const getLikedConversations = (userId: string) => {
 export const getPublicConverstaions = (userId: string) => {
   return request.get(endpoints.publicConversations(userId));
 }
+
+export const followUser = (payload: object): Promise<t.TUser> => {
+  return request.post(endpoints.followUser(), { arg: payload });
+}

--- a/packages/data-provider/src/react-query-service.ts
+++ b/packages/data-provider/src/react-query-service.ts
@@ -54,7 +54,7 @@ export const useGetUserQuery = (
 
 export const useGetUserByIdQuery = (
   id: string,
-) => {
+): QueryObserverResult<t.TUser> => {
   return useQuery([QueryKeys.userById, id], () => dataService.getUserById(id), {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
@@ -416,3 +416,7 @@ export const useGetPublicConversationQuery = (userId: string): QueryObserverResu
     retry: 1
   });
 }
+
+export const useFollowUserMutation = (): UseMutationResult<t.TUser, unknown, object, unknown> => {
+  return useMutation((payload: object) => dataService.followUser(payload));
+};

--- a/packages/data-provider/src/react-query-service.ts
+++ b/packages/data-provider/src/react-query-service.ts
@@ -420,3 +420,18 @@ export const useGetPublicConversationQuery = (userId: string): QueryObserverResu
 export const useFollowUserMutation = (): UseMutationResult<t.TUser, unknown, object, unknown> => {
   return useMutation((payload: object) => dataService.followUser(payload));
 };
+
+export const useLikeConversationMutation = (
+  id: string
+) => {
+  const queryClient = useQueryClient();
+  return useMutation(
+    (payload: object) => dataService.likeConversation(payload),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries([QueryKeys.conversation, id]);
+        queryClient.invalidateQueries([QueryKeys.allConversations]);
+      }
+    }
+  );
+};

--- a/packages/data-provider/src/react-query-service.ts
+++ b/packages/data-provider/src/react-query-service.ts
@@ -16,6 +16,7 @@ export enum QueryKeys {
   conversation = 'conversation',
   searchEnabled = 'searchEnabled',
   user = 'user',
+  userById = 'userById',
   endpoints = 'endpoints',
   presets = 'presets',
   searchResults = 'searchResults',
@@ -48,6 +49,17 @@ export const useGetUserQuery = (
     refetchOnMount: false,
     retry: false,
     ...config
+  });
+};
+
+export const useGetUserByIdQuery = (
+  id: string,
+) => {
+  return useQuery([QueryKeys.userById, id], () => dataService.getUserById(id), {
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchOnMount: false,
+    retry: false,
   });
 };
 

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -160,6 +160,8 @@ export type TUser = {
   numOfReferrals: number;
   createdAt: string;
   updatedAt: string;
+  followers: object;
+  following: object;
 };
 
 export type TGetConversationsResponse = {


### PR DESCRIPTION
## New
- Implemented follow/unfollow user feature
- Allow viewing user's followers and who they are following on their profile page

## Changes
- Renamed Homepage.tsx to Recommendations.tsx
  - Correspondingly on the menu, changed 主页 (Home) to 对话推荐 (Recommendations) and 个人资料 to 我的主页
- Replace fetch API with react query for liking conversations (Recommendations, shared conversation, and chat page)

## Enhancements
- Added a button on the profile page to copy user profile URL
- Allow access to user's profiles without logging in
- (On profile page) Sorts liked conversation/followers/following by most recently liked/most recent follower/most recently followed first